### PR TITLE
Added rotate plugin

### DIFF
--- a/src/rotate.coffee
+++ b/src/rotate.coffee
@@ -1,0 +1,43 @@
+Caman.Plugin.register "rotate", (degrees) ->
+  angle = degrees%360
+  if angle == 0 
+    return @dimensions =
+      width: @canvas.width
+      height: @canvas.height 
+  to_radians = Math.PI/180;
+ 
+  if exports?
+    canvas = new Canvas()
+  else
+    canvas = document.createElement 'canvas'  
+    Util.copyAttributes @canvas, canvas
+  
+  if angle == 90 or angle == -270 or angle == 270 or angle == -90
+    width = @canvas.height
+    height = @canvas.width
+    x = width/2
+    y = height/2
+  else if angle == 180
+    width = @canvas.width
+    height = @canvas.height
+    x = width/2
+    y = height/2 
+  else 
+    width = Math.sqrt(Math.pow(@originalWidth, 2) + Math.pow(@originalHeight, 2))
+    height = width
+    x = @canvas.height/2
+    y = @canvas.width/2
+  
+  canvas.width = width
+  canvas.height = height
+  ctx = canvas.getContext '2d'
+  ctx.save()
+  ctx.translate x, y	
+  ctx.rotate angle*to_radians
+  ctx.drawImage @canvas, -@canvas.width/2, -@canvas.height/2, @canvas.width, @canvas.height
+  ctx.restore()
+
+  @replaceCanvas canvas
+
+Caman.Filter.register "rotate", ->
+  @processPlugin "rotate", Array.prototype.slice.call(arguments, 0)


### PR DESCRIPTION
It allows to rotate an image, according to any angle.
To do this, you  must call function caman.rotate(degrees), where
degrees must be a number (positive or negative, on depends if you
want that your image rotates in clockwise direction or
counterclockwise direction).
If degrees is a multiple of 90 canvas mantains the dimensions
of image, otherwise the canvas will become larger, with height and
width equals to the diagonal of the image.
