### PR TITLE
Added two new rotation plugins that have more intuitive behavior

### DIFF
--- a/src/rotateBoundingBox.coffee
+++ b/src/rotateBoundingBox.coffee
@@ -1,0 +1,54 @@
+Caman.Plugin.register 'rotateBoundingBox', (degrees) ->
+  angle = (degrees % 360 + 360 ) % 360
+  if angle == 0
+    return @dimensions =
+      width: @canvas.width
+      height: @canvas.height
+
+  toRadians = Math.PI / 180
+
+  if exports?
+    canvas = new Canvas()
+  else
+    canvas = document.createElement 'canvas'
+    Util.copyAttributes @canvas, canvas
+  
+  switch
+    when angle <= 90
+      theta = angle * toRadians
+      width = @canvas.width * Math.cos(theta) + @canvas.height * Math.sin(theta)
+      height = @canvas.height * Math.cos(theta) + @canvas.width * Math.sin(theta)
+      x = @canvas.height * Math.sin(theta)
+      y = 0
+    when 90 < angle <= 180
+      theta = (angle - 90) * toRadians
+      width = @canvas.height * Math.cos(theta) + @canvas.width * Math.sin(theta)
+      height = @canvas.width * Math.cos(theta) + @canvas.height * Math.sin(theta)
+      x = @canvas.width * Math.sin(theta) + @canvas.height * Math.cos(theta)
+      y = @canvas.height * Math.sin(theta)
+    when 180 < angle <= 270
+      theta = (angle - 180) * toRadians
+      width = @canvas.width * Math.cos(theta) + @canvas.height * Math.sin(theta)
+      height = @canvas.height * Math.cos(theta) + @canvas.width * Math.sin(theta)
+      x = @canvas.width * Math.cos(theta)
+      y = @canvas.width * Math.sin(theta) + @canvas.height * Math.cos(theta)
+    else
+      theta = (angle - 270) * toRadians
+      width = @canvas.height * Math.cos(theta) + @canvas.width * Math.sin(theta)
+      height = @canvas.width * Math.cos(theta) + @canvas.height * Math.sin(theta)
+      x = 0
+      y = @canvas.width * Math.cos(theta)
+  
+  canvas.width = width
+  canvas.height = height
+  ctx = canvas.getContext '2d'
+  ctx.save()
+  ctx.translate x, y
+  ctx.rotate angle * toRadians
+  ctx.drawImage @canvas, 0, 0, @canvas.width, @canvas.height
+  ctx.restore()
+
+  @replaceCanvas canvas
+
+caman.Filter.register 'rotateBoundingBox', ->
+  @processPlugin 'rotateBoundingBox', Array.prototype.slice.call(arguments, 0)

--- a/src/rotateSquareBox.coffee
+++ b/src/rotateSquareBox.coffee
@@ -1,0 +1,25 @@
+Caman.Plugin.register "rotateSquareBox", (degrees) ->
+  angle = degrees%360
+  toRadians = Math.PI/180
+ 
+  if exports?
+    canvas = new Canvas()
+  else
+    canvas = document.createElement 'canvas'
+    Util.copyAttributes @canvas, canvas
+  
+  width = Math.sqrt(Math.pow(@originalWidth, 2) + Math.pow(@originalHeight, 2))
+  height = width
+  canvas.width = width
+  canvas.height = height
+  ctx = canvas.getContext '2d'
+  ctx.save()
+  ctx.translate width/2, height/2 
+  ctx.rotate angle*toRadians
+  ctx.drawImage @canvas, -@canvas.width/2, -@canvas.height/2, @canvas.width, @canvas.height
+  ctx.restore()
+
+  @replaceCanvas canvas
+
+Caman.Filter.register "rotateSquareBox", ->
+  @processPlugin "rotateSquareBox", Array.prototype.slice.call(arguments, 0)


### PR DESCRIPTION
I was pretty confused by the existing rotation plugin. It makes sense of 90º rotations, but for anything else, it makes a box thats big enough to house the new image but then doesn't render it in the center. I wasn't sure if preserving the behavior of the original is important or not, so my changes add two new rotation plugins. The first, rotateSquareBox, behaves just like the original should (I think) for non 90º rotations, and for 90º rotations keeps the square-box behavior for consistency. The second, rotateBoundingBox, makes a canvas exactly as big as required to house the rotation and no larger, therefore it behaves like the original for 90º rotations and has a more intuitive behavior for other rotations.
