### PR TITLE
rotate by -180 was not covered

### DIFF
--- a/src/rotate.coffee
+++ b/src/rotate.coffee
@@ -17,7 +17,7 @@ Caman.Plugin.register "rotate", (degrees) ->
     height = @canvas.width
     x = width/2
     y = height/2
-  else if angle == 180
+  else if angle == 180 or angle == -180
     width = @canvas.width
     height = @canvas.height
     x = width/2


### PR DESCRIPTION
Using the rotate function with -180 degrees has some weird side effect. The image is smaller than it should be. I guess my fix should help but I have not tested it.
